### PR TITLE
No longer limit an icon to 10 images

### DIFF
--- a/py2exe/icons.py
+++ b/py2exe/icons.py
@@ -86,8 +86,6 @@ def CreateGrpIconDirHeader(iconheader, id_generator):
                     ("idEntries", GRPICONDIRENTRY * iconheader.idCount)]
         def tobytes(self):
             return memoryview(self).tobytes()
-    if iconheader.idCount > 10:
-        raise ValueError("too many images for this icon: %d" % iconheader.idCount)
     grpheader = GRPICONDIRHEADER(
         idReserved = iconheader.idReserved,
         idType = iconheader.idType,


### PR DESCRIPTION
See also https://github.com/nvaccess/nvda/issues/8375#issuecomment-494412764

> I'm getting the following error from py2exe when trying to integrate [our ico file](https://github.com/nvaccess/nvda/blob/master/source/images/nvda.ico) into the executables:
> ``` Traceback (most recent call last): File "setup.py", line 225, in + getRecursiveDataFiles('documentation', '../user_docs', excludes=('*.t2t', '*.t2tconf', '*/developerGuide.*')) File "c:\python37\lib\distutils\core.py", line 148, in setup dist.run_commands() File "c:\python37\lib\distutils\dist.py", line 966, in run_commands self.run_command(cmd) File "c:\python37\lib\distutils\dist.py", line 985, in run_command cmd_obj.run() File "setup.py", line 97, in run super(py2exe, self).run() File "c:\python37\lib\site-packages\py2exe\distutils_buildexe.py", line 192, in run self._run() File "c:\python37\lib\site-packages\py2exe\distutils_buildexe.py", line 273, in _run builder.build() File "c:\python37\lib\site-packages\py2exe\runtime.py", line 235, in build self.build_exe(target, exe_path, options.libname) File "c:\python37\lib\site-packages\py2exe\runtime.py", line 377, in build_exe for res_type, res_name, res_data in BuildIcons(getattr(target, "icon_resources", ())): File "c:\python37\lib\site-packages\py2exe\icons.py", line 124, in BuildIcons grp_header = CreateGrpIconDirHeader(header, id_generator) File "c:\python37\lib\site-packages\py2exe\icons.py", line 90, in CreateGrpIconDirHeader raise ValueError("too many images for this icon: %d" % iconheader.idCount) ValueError: too many images for this icon: 11 ```

It turns out that the current py2exe somehow limits the number of images to 10, without giving a proper rationale for it. This code was introduced in bc4c86f4, which is a really huge commit.

With this pr, the error during build does no longer occur. Our ico contains 11 images, starting at resource id 10 and ranging up to and including 20. Inspection of the Python2 based executables reveals that the first image is saved with resource id 11, ranging up to and including 21. I'm reporting it just in case it would make a difference, which I think it doesn't.