### PR TITLE
Fix missing Py_DECREF for dynamic mod without init

### DIFF
--- a/source/_memimporter.c
+++ b/source/_memimporter.c
@@ -68,10 +68,10 @@ int do_import(FARPROC init_func, char *modname)
 		PyObject *msg = PyUnicode_FromFormat("dynamic module does not define "
 						     "init function (PyInit_%s)",
 						     modname);
-		if (msg == NULL)
-			return -1;
-		PyErr_SetImportError(msg, name, NULL);
-		Py_DECREF(msg);
+		if (msg != NULL) {
+			PyErr_SetImportError(msg, name, NULL);
+			Py_DECREF(msg);
+		}
 		Py_DECREF(name);
 		return -1;
 	}


### PR DESCRIPTION
Py_DECREF(name) was not called in case the error message could not be constructed.

Not a big issue IMO but I stumbled over it while reading through the source so I went ahead and fixed it.