### PR TITLE
Make sure that file names in tracebacks match the new file names

### DIFF
--- a/py2exe/mf3.py
+++ b/py2exe/mf3.py
@@ -672,16 +672,8 @@ class Module:
                 pass
 
     @property
-    def __compiled_file__(self):
-        """Gets the path for the module that will be used as file name at compilation time."""
-        try:
-            source = self.__source__
-        except:
-            source = None
-        if source is None:
-            if hasattr(self, __file__):
-                return self.__file__
-            raise RuntimeError("getting compiled file from %r" % self) from None
+    def __dest_file__(self):
+        """Gets the destination path for the module that will be used at compilation time."""
         if self.__optimize__:
             bytecode_suffix = OPTIMIZED_BYTECODE_SUFFIXES[0]
         else:
@@ -703,7 +695,7 @@ class Module:
                     raise RuntimeError("loading %r" % self) from None
                 if source is not None:
                     # XXX??? for py3exe:
-                    __file__ = self.__compiled_file__ \
+                    __file__ = self.__dest_file__ \
                                if hasattr(self, "__file__") else "<string>"
                     try:
                         self.__code_object__ = compile(source, __file__, "exec",

--- a/py2exe/runtime.py
+++ b/py2exe/runtime.py
@@ -417,10 +417,7 @@ class Runtime(object):
         # keys; we only need one of them in the archive.
         for mod in set(self.mf.modules.values()):
             if mod.__code__:
-                if hasattr(mod, "__path__"):
-                    path = mod.__name__.replace(".", "\\") + "\\__init__" + bytecode_suffix
-                else:
-                    path = mod.__name__.replace(".", "\\") + bytecode_suffix
+                path =mod.__compiled_file__
                 stream = io.BytesIO()
                 stream.write(imp.get_magic())
                 if sys.version_info >= (3,7,0):

--- a/py2exe/runtime.py
+++ b/py2exe/runtime.py
@@ -417,7 +417,7 @@ class Runtime(object):
         # keys; we only need one of them in the archive.
         for mod in set(self.mf.modules.values()):
             if mod.__code__:
-                path =mod.__compiled_file__
+                path =mod.__dest_file__
                 stream = io.BytesIO()
                 stream.write(imp.get_magic())
                 if sys.version_info >= (3,7,0):


### PR DESCRIPTION
See also nvaccess/nvda#9813 

In the old Py2exe, source files were always compiled, putting the new, byte compiled name of the file in place. This meant that in tracebacks, we had a nicely formatted name with the proper extension and without a reference to the compilation path of the build server. In the python 3 version of py2exe, this functionality was not available.

This pull request intends to fix this. Is does the following:

* Rather than relying on code objects that reside from the import loader directly, files for which the source is available are always compiled. If compilation there is still a fallback.
* When compiling code from source, make sure that we pass a file name at the compile function that corresponds with the destination file name, not the official source file name (including file system information)