### PR TITLE
Add hook for _ssl

### DIFF
--- a/py2exe/hooks.py
+++ b/py2exe/hooks.py
@@ -555,3 +555,16 @@ def hook_scipy_optimize(finder, module):
         finder.recursion_depth_optimize = depth + 1
         finder.import_hook("scipy.optimize.minpack2")
         finder.recursion_depth_optimize = depth
+
+def hook__ssl(finder, module):
+    """
+    On python 3.7 and above, _ssl.pyd requires additional dll's to load.
+    Based on code by Sebastian Krause: https://github.com/anthony-tuininga/cx_Freeze/pull/470
+    """
+    if sys.version_info < (3, 7):
+        return
+    import glob
+    for dll_search in ["libcrypto-*.dll", "libssl-*.dll"]:
+        for dll_path in glob.glob(os.path.join(sys.base_prefix, "DLLs", dll_search)):
+            dll_name = os.path.basename(dll_path)
+            finder.add_dll(dll_path)

--- a/py2exe/hooks.py
+++ b/py2exe/hooks.py
@@ -561,7 +561,7 @@ def hook__ssl(finder, module):
     On python 3.7 and above, _ssl.pyd requires additional dll's to load.
     Based on code by Sebastian Krause: https://github.com/anthony-tuininga/cx_Freeze/pull/470
     """
-    if sys.version_info < (3, 7):
+    if sys.version_info < (3, 7, 0):
         return
     import glob
     for dll_search in ["libcrypto-*.dll", "libssl-*.dll"]:


### PR DESCRIPTION
In python 3.7 and up, _ssl.pyd relies on libcrypto and libssl. These aren't picked up by py2exe, which is problematic for NVDA (see https://github.com/nvaccess/nvda/issues/9831)

This patch is based on https://github.com/anthony-tuininga/cx_Freeze/pull/470 by @sekrause. I made sure that after building an NVDA distribution with this patch applied, the libcrypto and libssl modules were copied successfully.