### PR TITLE
Do not attempt to obtain the source for Extension Modules

### DIFF
--- a/py2exe/mf3.py
+++ b/py2exe/mf3.py
@@ -687,6 +687,8 @@ class Module:
     @property
     def __code__(self):
         if self.__code_object__ is None:
+            if self.__loader__.__class__ == importlib.machinery.ExtensionFileLoader:
+                return None
             try:
                 try:
                     source = self.__source__


### PR DESCRIPTION
This will always fail and if the extension is not PYD it will throw
a runtime error.

Fixes #27.